### PR TITLE
Revert "tmpfs: clear S_ISGID when setting posix ACLs"

### DIFF
--- a/fs/posix_acl.c
+++ b/fs/posix_acl.c
@@ -359,9 +359,11 @@ int posix_acl_update_mode(struct inode *inode, umode_t *mode_p,
 	umode_t mode = inode->i_mode;
 	int error;
 
-	error = posix_acl_update_mode(inode, &inode->i_mode, acl);
-	if (error)
+	error = posix_acl_equiv_mode(*acl, &mode);
+	if (error < 0)
 		return error;
+	if (error == 0)
+		*acl = NULL;
 	if (!in_group_p(inode->i_gid) &&
 	    !capable(CAP_FSETID))
 		mode &= ~S_ISGID;


### PR DESCRIPTION
This is just wrong, the change makes no sense.

This reverts commit ae466fb65d4b661fa07fc8c562e914c60e021ab9.

Change-Id: I7debedbd7087e6085496fd410813091883bfb87f